### PR TITLE
Fix: - Fixed typerror on clicking datepicker popup

### DIFF
--- a/src/app/ngb-date-firestore-adapter.service.ts
+++ b/src/app/ngb-date-firestore-adapter.service.ts
@@ -26,6 +26,9 @@ export class NgbDateFirestoreAdapter extends NgbDateAdapter<firestore.Timestamp>
    * Converts a NgbDateStruct to a Firestore TimeStamp
    */
   toModel(ngbDate: NgbDateStruct): firestore.Timestamp {
+    if (!ngbDate) {
+      return null;
+    }
     const jsDate = new Date(
       ngbDate.year ? ngbDate.year : new Date().getFullYear(),
       ngbDate.month ? ngbDate.month - 1 : new Date().getMonth() - 1,


### PR DESCRIPTION
### Typerror is thrown when date picker with pop up is used

In converting an ngDateStruct to firebase timestamp, typerror is thrown when a datepicker pop up is clicked.

On clicking the pop up, the ngDateStruct passed to the toModel is null and therefore causes typerror to be thrown.

I hadled the instance when the ngDateStruct is null


![Screenshot (349)](https://user-images.githubusercontent.com/34287487/79281001-65255000-7ea1-11ea-8af0-d0d15b7f128b.png)
